### PR TITLE
Gate datalogging behind compile flag

### DIFF
--- a/include/datalogging.h
+++ b/include/datalogging.h
@@ -3,6 +3,10 @@
 
 #include <Arduino.h>
 
+#ifndef ENABLE_DATALOGGING
+#define ENABLE_DATALOGGING 0
+#endif
+
 // Initializes the SD card and opens files for logging raw and filtered sensor data.
 void setupFiles();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,8 +17,10 @@ void setup() {
   float initialAltitude = getRelativeAltitude();
   ekfInit(0.0f, initialAltitude, 0.0f, 0.0f, 0.0f, 0.0f);
   resetIntegratedAngles();
+#if ENABLE_DATALOGGING
   setupFiles();
   Summarylog("Core debug loop initialized with EKF and datalogging enabled.");
+#endif
 }
 
 void loop() {
@@ -60,7 +62,9 @@ void loop() {
   float x, y, z, vx, vy, vz;
   ekfGetState(x, y, z, vx, vy, vz);
 
+#if ENABLE_DATALOGGING
   logSensorData();
+#endif
 
   float roll, pitch, yaw;
   getIntegratedAngles(roll, pitch, yaw);


### PR DESCRIPTION
## Summary
- add an ENABLE_DATALOGGING compile flag defaulting to off
- wrap datalogging setup and usage in compile-time guards to disable logging calls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de67b90688329bc5f3fa0d1d87fe0)