### PR TITLE
Implement firmware-based sensor noise characterization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,15 @@
 #include <Arduino.h>
 #include <Wire.h>
 #include "sensor_setup.h"
-#include "ekf_sensor_fusion.h"
-#include "orientation_estimation.h"
-#include "datalogging.h"
+// #include "ekf_sensor_fusion.h"
+// #include "orientation_estimation.h"
+// #include "datalogging.h"
+
+#include <vector>
+#include <numeric>
+#include <cmath>
+
+const float COLLECTION_DURATION_SECONDS = 10.0f; // exposed collection duration
 
 const uint32_t LOOP_PERIOD_US = 5000; // 200 Hz core loop
 
@@ -14,13 +20,9 @@ void setup() {
   }
 
   setupSensors();
-  float initialAltitude = getRelativeAltitude();
-  ekfInit(0.0f, initialAltitude, 0.0f, 0.0f, 0.0f, 0.0f);
-  resetIntegratedAngles();
-#if ENABLE_DATALOGGING
-  setupFiles();
-  Summarylog("Core debug loop initialized with EKF and datalogging enabled.");
-#endif
+  Serial.println("Beginning sensor noise characterization run...");
+  Serial.print("Configured collection duration (s): ");
+  Serial.println(COLLECTION_DURATION_SECONDS, 3);
 }
 
 void loop() {
@@ -33,7 +35,39 @@ void loop() {
   }
 
   lastUpdate = now;
-  float dt = elapsed / 1e6f;
+
+  static bool initializedBuffers = false;
+  static uint32_t startMillis = millis();
+  static std::vector<float> bnoAccelX, bnoAccelY, bnoAccelZ;
+  static std::vector<float> bnoGyroX, bnoGyroY, bnoGyroZ;
+  static std::vector<float> bnoMagX, bnoMagY, bnoMagZ;
+  static std::vector<float> bmxAccelX, bmxAccelY, bmxAccelZ;
+  static std::vector<float> bmxGyroX, bmxGyroY, bmxGyroZ;
+  static std::vector<float> bmxMagX, bmxMagY, bmxMagZ;
+  static std::vector<float> baroAltitude;
+
+  if (!initializedBuffers) {
+    bnoAccelX.reserve(2000);
+    bnoAccelY.reserve(2000);
+    bnoAccelZ.reserve(2000);
+    bnoGyroX.reserve(2000);
+    bnoGyroY.reserve(2000);
+    bnoGyroZ.reserve(2000);
+    bnoMagX.reserve(2000);
+    bnoMagY.reserve(2000);
+    bnoMagZ.reserve(2000);
+    bmxAccelX.reserve(2000);
+    bmxAccelY.reserve(2000);
+    bmxAccelZ.reserve(2000);
+    bmxGyroX.reserve(2000);
+    bmxGyroY.reserve(2000);
+    bmxGyroZ.reserve(2000);
+    bmxMagX.reserve(2000);
+    bmxMagY.reserve(2000);
+    bmxMagZ.reserve(2000);
+    baroAltitude.reserve(2000);
+    initializedBuffers = true;
+  }
 
   float bnoAx, bnoAy, bnoAz, bnoGx, bnoGy, bnoGz, bnoMx, bnoMy, bnoMz;
   getSensorData(bnoAx, bnoAy, bnoAz, bnoGx, bnoGy, bnoGz, bnoMx, bnoMy, bnoMz);
@@ -43,88 +77,104 @@ void loop() {
   float bmxMx = 0.0f, bmxMy = 0.0f, bmxMz = 0.0f;
   bool bmxOk = getBMXSensorData(bmxAx, bmxAy, bmxAz, bmxGx, bmxGy, bmxGz, bmxMx, bmxMy, bmxMz);
 
-  float ax = bmxOk ? bmxAx : bnoAx;
-  float ay = bmxOk ? bmxAy : bnoAy;
-  float az = bmxOk ? bmxAz : bnoAz;
-  float gx = bmxOk ? bmxGx : bnoGx;
-  float gy = bmxOk ? bmxGy : bnoGy;
-  float gz = bmxOk ? bmxGz : bnoGz;
-  float mx = bmxOk ? bmxMx : bnoMx;
-  float my = bmxOk ? bmxMy : bnoMy;
-  float mz = bmxOk ? bmxMz : bnoMz;
   float relAlt = getRelativeAltitude();
 
-  ekfPredict(ax, ay, az, dt);
-  ekfUpdateBaro(relAlt);
-
-  updateIntegratedAngles(gx, gy, gz, dt);
-
-  float x, y, z, vx, vy, vz;
-  ekfGetState(x, y, z, vx, vy, vz);
-
-#if ENABLE_DATALOGGING
-  logSensorData();
-#endif
-
-  float roll, pitch, yaw;
-  getIntegratedAngles(roll, pitch, yaw);
-
-  Serial.print(">alt_fused:");
-  Serial.print(y, 3);
-  Serial.print(",vel_fused:");
-  Serial.print(vy, 3);
-  Serial.print(",alt_raw:");
-  Serial.print(relAlt, 3);
-  Serial.print(",ax:");
-  Serial.print(ax, 3);
-  Serial.print(",ay:");
-  Serial.print(ay, 3);
-  Serial.print(",az:");
-  Serial.print(az, 3);
-  Serial.print(",roll:");
-  Serial.print(roll, 3);
-  Serial.print(",pitch:");
-  Serial.print(pitch, 3);
-  Serial.print(",yaw:");
-  Serial.print(yaw, 3);
-  Serial.print(",bno_ax:");
-  Serial.print(bnoAx, 3);
-  Serial.print(",bno_ay:");
-  Serial.print(bnoAy, 3);
-  Serial.print(",bno_az:");
-  Serial.print(bnoAz, 3);
-  Serial.print(",bno_gx:");
-  Serial.print(bnoGx, 3);
-  Serial.print(",bno_gy:");
-  Serial.print(bnoGy, 3);
-  Serial.print(",bno_gz:");
-  Serial.print(bnoGz, 3);
-  Serial.print(",bno_mx:");
-  Serial.print(bnoMx, 3);
-  Serial.print(",bno_my:");
-  Serial.print(bnoMy, 3);
-  Serial.print(",bno_mz:");
-  Serial.print(bnoMz, 3);
+  bnoAccelX.push_back(bnoAx);
+  bnoAccelY.push_back(bnoAy);
+  bnoAccelZ.push_back(bnoAz);
+  bnoGyroX.push_back(bnoGx);
+  bnoGyroY.push_back(bnoGy);
+  bnoGyroZ.push_back(bnoGz);
+  bnoMagX.push_back(bnoMx);
+  bnoMagY.push_back(bnoMy);
+  bnoMagZ.push_back(bnoMz);
+  baroAltitude.push_back(relAlt);
 
   if (bmxOk) {
-    Serial.print(",bmx_ax:");
-    Serial.print(bmxAx, 3);
-    Serial.print(",bmx_ay:");
-    Serial.print(bmxAy, 3);
-    Serial.print(",bmx_az:");
-    Serial.print(bmxAz, 3);
-    Serial.print(",bmx_gx:");
-    Serial.print(bmxGx, 3);
-    Serial.print(",bmx_gy:");
-    Serial.print(bmxGy, 3);
-    Serial.print(",bmx_gz:");
-    Serial.print(bmxGz, 3);
-    Serial.print(",bmx_mx:");
-    Serial.print(bmxMx, 3);
-    Serial.print(",bmx_my:");
-    Serial.print(bmxMy, 3);
-    Serial.print(",bmx_mz:");
-    Serial.print(bmxMz, 3);
+    bmxAccelX.push_back(bmxAx);
+    bmxAccelY.push_back(bmxAy);
+    bmxAccelZ.push_back(bmxAz);
+    bmxGyroX.push_back(bmxGx);
+    bmxGyroY.push_back(bmxGy);
+    bmxGyroZ.push_back(bmxGz);
+    bmxMagX.push_back(bmxMx);
+    bmxMagY.push_back(bmxMy);
+    bmxMagZ.push_back(bmxMz);
   }
-  Serial.print("\r\n");
+
+  float elapsedSeconds = (millis() - startMillis) / 1000.0f;
+  if (elapsedSeconds < COLLECTION_DURATION_SECONDS) {
+    return;
+  }
+
+  Serial.println("Collection complete. Computing statistics...");
+  const float sampleRateHz = 1e6f / static_cast<float>(LOOP_PERIOD_US);
+
+  auto printStats = [&](const char *label, const std::vector<float> &data) {
+    if (data.empty()) {
+      Serial.print(label);
+      Serial.println(": no data recorded");
+      return;
+    }
+    const size_t n = data.size();
+    float mean = std::accumulate(data.begin(), data.end(), 0.0f) / n;
+    float variance = 0.0f;
+    for (float v : data) {
+      float diff = v - mean;
+      variance += diff * diff;
+    }
+    variance /= (n > 1 ? (n - 1) : 1);
+    float stddev = sqrtf(variance);
+
+    float allanNumerator = 0.0f;
+    if (n > 1) {
+      for (size_t i = 0; i + 1 < n; ++i) {
+        float delta = data[i + 1] - data[i];
+        allanNumerator += delta * delta;
+      }
+      allanNumerator /= (2.0f * (n - 1));
+    }
+    float allanDeviation = sqrtf(allanNumerator);
+
+    float psd = variance / sampleRateHz;
+
+    Serial.print(label);
+    Serial.print(",mean:");
+    Serial.print(mean, 6);
+    Serial.print(",std:");
+    Serial.print(stddev, 6);
+    Serial.print(",allan:");
+    Serial.print(allanDeviation, 6);
+    Serial.print(",psd:");
+    Serial.println(psd, 6);
+  };
+
+  printStats("BNO055_AX", bnoAccelX);
+  printStats("BNO055_AY", bnoAccelY);
+  printStats("BNO055_AZ", bnoAccelZ);
+  printStats("BNO055_GX", bnoGyroX);
+  printStats("BNO055_GY", bnoGyroY);
+  printStats("BNO055_GZ", bnoGyroZ);
+  printStats("BNO055_MX", bnoMagX);
+  printStats("BNO055_MY", bnoMagY);
+  printStats("BNO055_MZ", bnoMagZ);
+
+  printStats("BMX160_AX", bmxAccelX);
+  printStats("BMX160_AY", bmxAccelY);
+  printStats("BMX160_AZ", bmxAccelZ);
+  printStats("BMX160_GX", bmxGyroX);
+  printStats("BMX160_GY", bmxGyroY);
+  printStats("BMX160_GZ", bmxGyroZ);
+  printStats("BMX160_MX", bmxMagX);
+  printStats("BMX160_MY", bmxMagY);
+  printStats("BMX160_MZ", bmxMagZ);
+
+  printStats("BARO_ALT", baroAltitude);
+
+  Serial.println("Noise characterization complete. Please capture this log to a text file on the host PC.");
+
+  while (true) {
+    delay(1000);
+  }
 }
+

--- a/src/sensor_setup.cpp
+++ b/src/sensor_setup.cpp
@@ -27,9 +27,9 @@ void setupSensors() {
   Summarylog("BNO055 initialized successfully.");
   Summarylog("BNO External Crystal = True");
   bno.setExtCrystalUse(true);
-  bno.setSensorOffsets(BNO_CALIBRATION_OFFSETS);
-  Serial.println("BNO055 calibration offsets applied.");
-  Summarylog("BNO055 calibration offsets applied.");
+  // bno.setSensorOffsets(BNO_CALIBRATION_OFFSETS);
+  // Serial.println("BNO055 calibration offsets applied.");
+  // Summarylog("BNO055 calibration offsets applied.");
 
   if (!bmx160.begin()) {
     Serial.println("BMX160 initialization failed!");
@@ -55,10 +55,10 @@ void setupSensors() {
   bmp.setIIRFilterCoeff(BMP3_IIR_FILTER_DISABLE);
   bmp.setOutputDataRate(BMP3_ODR_200_HZ);
 
-  altitudeBias = manualCalibrateBMP388();
-  Serial.print("Manual calibration complete. Altitude bias: ");
-  Serial.println(altitudeBias, 3);
-  Summarylog(String("Manual calibration complete. Altitude bias: ")+ altitudeBias);
+  // altitudeBias = manualCalibrateBMP388();
+  // Serial.print("Manual calibration complete. Altitude bias: ");
+  // Serial.println(altitudeBias, 3);
+  // Summarylog(String("Manual calibration complete. Altitude bias: ")+ altitudeBias);
 
   if (bmp.performReading()) {
     baselineAltitude = bmp.readAltitude(1013.25) - altitudeBias;


### PR DESCRIPTION
## Summary
- replace the host-side Python tool with firmware-based collection and characterization of BNO055, BMX160, and barometer readings
- disable EKF/datalogging paths in main.cpp in favor of capturing sensor samples for a configurable duration and printing mean, std, Allan deviation, and PSD per axis
- skip sensor calibration steps in sensor_setup.cpp to keep the firmware focused on raw noise measurement

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345d60db208329a2f64afecc9b701c)