### PR TITLE
Add 12- and 15-state INS EKF implementations

### DIFF
--- a/include/ins_ekf.h
+++ b/include/ins_ekf.h
@@ -1,0 +1,124 @@
+#ifndef INS_EKF_H
+#define INS_EKF_H
+
+#include <Arduino.h>
+
+/*
+ * INS Error-State EKF Summary
+ *
+ * Nominal states (shared by 12- and 15-state variants):
+ *   p_nom ∈ R^3 : position in navigation frame (Y-up)
+ *   v_nom ∈ R^3 : velocity in navigation frame
+ *   q_nom ∈ R^4 : unit quaternion (body → navigation)
+ *   b_a_nom ∈ R^3 : accelerometer bias (body)
+ *   b_g_nom ∈ R^3 : gyro bias (body, only used by 15-state numerics)
+ *
+ * Error-state vectors:
+ *   12-state δx12 = [δp(3); δv(3); δθ(3); δb_a(3)]
+ *   15-state δx15 = [δp(3); δv(3); δθ(3); δb_a(3); δb_g(3)]
+ *
+ * Nominal dynamics:
+ *   ṗ = v
+ *   v̇ = R_bn(q) · (a_m - b_a) + g_n        (g_n = [0, -g, 0] for Y-up)
+ *   q̇ = 0.5 · Ω(ω_m - b_g) · q              (Ω is quaternion rate matrix)
+ *   ḃ_a = 0 + noise_ba
+ *   ḃ_g = 0 + noise_bg
+ *
+ * Error dynamics Jacobian Fc (major blocks):
+ *   δṗ = δv
+ *   δv̇ = -R_bn · skew(â) · δθ - R_bn · δb_a
+ *   δθ̇ = -skew(ω̂) · δθ - δb_g (15-state only)
+ *   δḃ_a = noise; δḃ_g = noise
+ *
+ * Measurement model (baro altitude):
+ *   z_baro = e_h^T · p + v_b , with e_h = [0 1 0]^T (Y-up altitude)
+ *   Linearized: z ≈ h(p_nom) + e_h^T δp + v_b → H = [e_h^T 0 0 0 0]
+ *
+ * Noise design:
+ *   Process noise Q derived from BMX160 averages (200 Hz):
+ *     accel PSD S_a ≈ 4.75e-4 (m/s^2)^2/Hz → σ_v^2 ≈ S_a·dt
+ *     gyro PSD  S_g ≈ 5.60e-4 (rad/s)^2/Hz → σ_θ^2 ≈ S_g·dt
+ *     accel bias RW via Allan A_a ≈ 8.71e-2 → S_ba ≈ A_a^2/1s, Q_ba ≈ S_ba·dt
+ *     gyro bias RW  via Allan A_g ≈ 2.08e-1 → S_bg ≈ A_g^2/1s, Q_bg ≈ S_bg·dt
+ *     Position noise uses simple integrated white accel model σ_p^2 ≈ (1/3) S_a·dt^3
+ *   Measurement noise R from BMP388 bench noise: choose σ_baro ≈ 3 m → R = σ_baro^2
+ */
+
+class INSEKF12 {
+public:
+  static const int N = 12;
+
+  INSEKF12();
+
+  void initialize(const float *p0, const float *v0, const float *q0,
+                  const float *ba0, const float *bg0);
+  void setDt(float dtSeconds);
+  void setProcessNoiseFromSensors();
+  void setMeasurementNoiseFromSensors();
+  void predict(const float *a_m, const float *w_m);
+  void updateBaro(float z_baro);
+
+  const float *position() const { return p_nom; }
+  const float *velocity() const { return v_nom; }
+  const float *quaternion() const { return q_nom; }
+  const float *accelBias() const { return b_a_nom; }
+  const float *gyroBias() const { return b_g_nom; }
+
+private:
+  float dt;
+  float p_nom[3];
+  float v_nom[3];
+  float q_nom[4];
+  float b_a_nom[3];
+  float b_g_nom[3];
+
+  float P[N][N];
+  float Q[N][N];
+  float R[1][1];
+
+  void resetCovariance();
+  void buildFc(const float *a_corr, const float *w_corr, float Fc[N][N]) const;
+  void propagateCovariance(const float Fc[N][N]);
+  void injectErrorState(const float *dx);
+};
+
+class INSEKF15 {
+public:
+  static const int N = 15;
+
+  INSEKF15();
+
+  void initialize(const float *p0, const float *v0, const float *q0,
+                  const float *ba0, const float *bg0);
+  void setDt(float dtSeconds);
+  void setProcessNoiseFromSensors();
+  void setMeasurementNoiseFromSensors();
+  void predict(const float *a_m, const float *w_m);
+  void updateBaro(float z_baro);
+
+  const float *position() const { return p_nom; }
+  const float *velocity() const { return v_nom; }
+  const float *quaternion() const { return q_nom; }
+  const float *accelBias() const { return b_a_nom; }
+  const float *gyroBias() const { return b_g_nom; }
+
+private:
+  float dt;
+  float p_nom[3];
+  float v_nom[3];
+  float q_nom[4];
+  float b_a_nom[3];
+  float b_g_nom[3];
+
+  float P[N][N];
+  float Q[N][N];
+  float R[1][1];
+
+  void resetCovariance();
+  void buildFc(const float *a_corr, const float *w_corr, float Fc[N][N]) const;
+  void propagateCovariance(const float Fc[N][N]);
+  void injectErrorState(const float *dx);
+};
+
+#endif // INS_EKF_H
+

--- a/src/ins_ekf.cpp
+++ b/src/ins_ekf.cpp
@@ -1,0 +1,599 @@
+#include "ins_ekf.h"
+#include <math.h>
+
+static const float GRAVITY = 9.80665f;
+
+static void zeroMatrix(float *M, int rows, int cols) {
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      M[r * cols + c] = 0.0f;
+    }
+  }
+}
+
+static void identityMatrix(float *M, int n) {
+  zeroMatrix(M, n, n);
+  for (int i = 0; i < n; ++i) {
+    M[i * n + i] = 1.0f;
+  }
+}
+
+static void copyMatrix(const float *A, float *B, int rows, int cols) {
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      B[r * cols + c] = A[r * cols + c];
+    }
+  }
+}
+
+static void matMul(const float *A, const float *B, float *C, int m, int n,
+                   int p) {
+  // C = A(mxn) * B(nxp)
+  for (int i = 0; i < m; ++i) {
+    for (int j = 0; j < p; ++j) {
+      float sum = 0.0f;
+      for (int k = 0; k < n; ++k) {
+        sum += A[i * n + k] * B[k * p + j];
+      }
+      C[i * p + j] = sum;
+    }
+  }
+}
+
+static void matAdd(const float *A, const float *B, float *C, int rows,
+                   int cols) {
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      C[r * cols + c] = A[r * cols + c] + B[r * cols + c];
+    }
+  }
+}
+
+static void matSub(const float *A, const float *B, float *C, int rows,
+                   int cols) {
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      C[r * cols + c] = A[r * cols + c] - B[r * cols + c];
+    }
+  }
+}
+
+static void matTrans(const float *A, float *AT, int rows, int cols) {
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      AT[c * rows + r] = A[r * cols + c];
+    }
+  }
+}
+
+static void skew(const float v[3], float S[9]) {
+  S[0] = 0.0f;
+  S[1] = -v[2];
+  S[2] = v[1];
+  S[3] = v[2];
+  S[4] = 0.0f;
+  S[5] = -v[0];
+  S[6] = -v[1];
+  S[7] = v[0];
+  S[8] = 0.0f;
+}
+
+static void quatNormalize(float q[4]) {
+  float norm = sqrtf(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] +
+                     q[3] * q[3]);
+  if (norm > 0.0f) {
+    float inv = 1.0f / norm;
+    q[0] *= inv;
+    q[1] *= inv;
+    q[2] *= inv;
+    q[3] *= inv;
+  }
+}
+
+static void quatToRot(const float q[4], float R[9]) {
+  // q = [w, x, y, z]
+  const float w = q[0];
+  const float x = q[1];
+  const float y = q[2];
+  const float z = q[3];
+
+  const float ww = w * w;
+  const float xx = x * x;
+  const float yy = y * y;
+  const float zz = z * z;
+
+  R[0] = ww + xx - yy - zz;
+  R[1] = 2.0f * (x * y - w * z);
+  R[2] = 2.0f * (x * z + w * y);
+
+  R[3] = 2.0f * (x * y + w * z);
+  R[4] = ww - xx + yy - zz;
+  R[5] = 2.0f * (y * z - w * x);
+
+  R[6] = 2.0f * (x * z - w * y);
+  R[7] = 2.0f * (y * z + w * x);
+  R[8] = ww - xx - yy + zz;
+}
+
+static void quatIntegrate(const float q[4], const float w_b[3], float dt,
+                          float q_out[4]) {
+  // omega in rad/s
+  float dq[4];
+  dq[0] = 1.0f;
+  dq[1] = 0.5f * w_b[0] * dt;
+  dq[2] = 0.5f * w_b[1] * dt;
+  dq[3] = 0.5f * w_b[2] * dt;
+  quatNormalize(dq);
+
+  // q_out = dq ⊗ q
+  q_out[0] = dq[0] * q[0] - dq[1] * q[1] - dq[2] * q[2] - dq[3] * q[3];
+  q_out[1] = dq[0] * q[1] + dq[1] * q[0] + dq[2] * q[3] - dq[3] * q[2];
+  q_out[2] = dq[0] * q[2] - dq[1] * q[3] + dq[2] * q[0] + dq[3] * q[1];
+  q_out[3] = dq[0] * q[3] + dq[1] * q[2] - dq[2] * q[1] + dq[3] * q[0];
+  quatNormalize(q_out);
+}
+
+static void applyDeltaTheta(float q[4], const float dtheta[3]) {
+  float dq[4];
+  dq[0] = 1.0f;
+  dq[1] = 0.5f * dtheta[0];
+  dq[2] = 0.5f * dtheta[1];
+  dq[3] = 0.5f * dtheta[2];
+  quatNormalize(dq);
+
+  float q_new[4];
+  q_new[0] = dq[0] * q[0] - dq[1] * q[1] - dq[2] * q[2] - dq[3] * q[3];
+  q_new[1] = dq[0] * q[1] + dq[1] * q[0] + dq[2] * q[3] - dq[3] * q[2];
+  q_new[2] = dq[0] * q[2] - dq[1] * q[3] + dq[2] * q[0] + dq[3] * q[1];
+  q_new[3] = dq[0] * q[3] + dq[1] * q[2] - dq[2] * q[1] + dq[3] * q[0];
+
+  q[0] = q_new[0];
+  q[1] = q_new[1];
+  q[2] = q_new[2];
+  q[3] = q_new[3];
+  quatNormalize(q);
+}
+
+static void addVector(float *dst, const float *src, int n) {
+  for (int i = 0; i < n; ++i) {
+    dst[i] += src[i];
+  }
+}
+
+// ----------------------------------------------------------
+// INSEKF12 implementation
+// ----------------------------------------------------------
+
+INSEKF12::INSEKF12() : dt(0.005f) {
+  float p0[3] = {0.0f, 0.0f, 0.0f};
+  float v0[3] = {0.0f, 0.0f, 0.0f};
+  float q0[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+  float ba0[3] = {0.0f, 0.0f, 0.0f};
+  float bg0[3] = {0.0f, 0.0f, 0.0f};
+  initialize(p0, v0, q0, ba0, bg0);
+  setProcessNoiseFromSensors();
+  setMeasurementNoiseFromSensors();
+}
+
+void INSEKF12::initialize(const float *p0, const float *v0, const float *q0,
+                          const float *ba0, const float *bg0) {
+  for (int i = 0; i < 3; ++i) {
+    p_nom[i] = p0[i];
+    v_nom[i] = v0[i];
+    b_a_nom[i] = ba0[i];
+    b_g_nom[i] = bg0[i];
+  }
+  for (int i = 0; i < 4; ++i) {
+    q_nom[i] = q0[i];
+  }
+  quatNormalize(q_nom);
+  resetCovariance();
+}
+
+void INSEKF12::setDt(float dtSeconds) { dt = dtSeconds; }
+
+void INSEKF12::resetCovariance() {
+  zeroMatrix(&P[0][0], N, N);
+  for (int i = 0; i < N; ++i) {
+    P[i][i] = 1e-3f;
+  }
+}
+
+void INSEKF12::setProcessNoiseFromSensors() {
+  zeroMatrix(&Q[0][0], N, N);
+  const float Sa = 4.75e-4f;
+  const float Sg = 5.60e-4f;
+  const float AllanA = 8.71e-2f;
+
+  const float sigma_v2 = Sa * dt;
+  const float sigma_p2 = (1.0f / 3.0f) * Sa * dt * dt * dt;
+  const float sigma_theta2 = Sg * dt;
+  const float Sb_a = AllanA * AllanA;
+  const float q_ba = Sb_a * dt;
+
+  for (int i = 0; i < 3; ++i) {
+    Q[i][i] = sigma_p2;
+    Q[3 + i][3 + i] = sigma_v2;
+    Q[6 + i][6 + i] = sigma_theta2;
+    Q[9 + i][9 + i] = q_ba;
+  }
+}
+
+void INSEKF12::setMeasurementNoiseFromSensors() {
+  const float sigma_baro = 3.0f;
+  R[0][0] = sigma_baro * sigma_baro;
+}
+
+void INSEKF12::buildFc(const float *a_corr, const float *w_corr,
+                       float Fc[N][N]) const {
+  zeroMatrix(&Fc[0][0], N, N);
+  float Rbn[9];
+  quatToRot(q_nom, Rbn);
+
+  float skew_a[9];
+  skew(a_corr, skew_a);
+  float skew_w[9];
+  skew(w_corr, skew_w);
+
+  // δṗ = δv
+  for (int i = 0; i < 3; ++i) {
+    Fc[i][3 + i] = 1.0f;
+  }
+
+  // δv̇ terms
+  float tmp[9];
+  // -Rbn * skew(a)
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      float sum = 0.0f;
+      for (int k = 0; k < 3; ++k) {
+        sum += Rbn[r * 3 + k] * skew_a[k * 3 + c];
+      }
+      tmp[r * 3 + c] = -sum;
+    }
+  }
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      Fc[3 + r][6 + c] = tmp[r * 3 + c];
+    }
+  }
+
+  // -Rbn for accel bias
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      Fc[3 + r][9 + c] = -Rbn[r * 3 + c];
+    }
+  }
+
+  // δθ̇
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      Fc[6 + r][6 + c] = -skew_w[r * 3 + c];
+    }
+  }
+}
+
+void INSEKF12::propagateCovariance(const float Fc[N][N]) {
+  float Fk[N][N];
+  zeroMatrix(&Fk[0][0], N, N);
+  for (int i = 0; i < N; ++i) {
+    Fk[i][i] = 1.0f + Fc[i][i] * dt;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        Fk[i][j] += Fc[i][j] * dt;
+      }
+    }
+  }
+
+  float FP[N][N];
+  matMul(&Fk[0][0], &P[0][0], &FP[0][0], N, N, N);
+
+  float FkT[N][N];
+  matTrans(&Fk[0][0], &FkT[0][0], N, N);
+
+  float FPFt[N][N];
+  matMul(&FP[0][0], &FkT[0][0], &FPFt[0][0], N, N, N);
+
+  matAdd(&FPFt[0][0], &Q[0][0], &P[0][0], N, N);
+}
+
+void INSEKF12::injectErrorState(const float *dx) {
+  addVector(p_nom, dx, 3);
+  addVector(v_nom, dx + 3, 3);
+  applyDeltaTheta(q_nom, dx + 6);
+  addVector(b_a_nom, dx + 9, 3);
+}
+
+void INSEKF12::predict(const float *a_m, const float *w_m) {
+  float a_corr[3];
+  float w_corr[3];
+  for (int i = 0; i < 3; ++i) {
+    a_corr[i] = a_m[i] - b_a_nom[i];
+    w_corr[i] = w_m[i] - b_g_nom[i];
+  }
+
+  float Rbn[9];
+  quatToRot(q_nom, Rbn);
+
+  float acc_nav[3];
+  for (int r = 0; r < 3; ++r) {
+    acc_nav[r] = Rbn[r * 3 + 0] * a_corr[0] + Rbn[r * 3 + 1] * a_corr[1] +
+                 Rbn[r * 3 + 2] * a_corr[2];
+  }
+  acc_nav[1] -= GRAVITY;
+
+  for (int i = 0; i < 3; ++i) {
+    p_nom[i] += v_nom[i] * dt;
+    v_nom[i] += acc_nav[i] * dt;
+  }
+  quatIntegrate(q_nom, w_corr, dt, q_nom);
+
+  float Fc[N][N];
+  buildFc(a_corr, w_corr, Fc);
+  propagateCovariance(Fc);
+}
+
+void INSEKF12::updateBaro(float z_baro) {
+  // H = [0 1 0 0 ...]
+  float H[1][N];
+  zeroMatrix(&H[0][0], 1, N);
+  H[0][1] = 1.0f;
+
+  float PHt[N];
+  for (int r = 0; r < N; ++r) {
+    PHt[r] = P[r][1];
+  }
+
+  float S = P[1][1] + R[0][0];
+  float K[N];
+  for (int i = 0; i < N; ++i) {
+    K[i] = PHt[i] / S;
+  }
+
+  float innovation = z_baro - p_nom[1];
+  float dx[N];
+  for (int i = 0; i < N; ++i) {
+    dx[i] = K[i] * innovation;
+  }
+  injectErrorState(dx);
+
+  // P = (I-KH)P
+  float KH[N][N];
+  zeroMatrix(&KH[0][0], N, N);
+  for (int r = 0; r < N; ++r) {
+    KH[r][1] = K[r];
+  }
+
+  float IminusKH[N][N];
+  for (int r = 0; r < N; ++r) {
+    for (int c = 0; c < N; ++c) {
+      float val = (r == c) ? 1.0f : 0.0f;
+      IminusKH[r][c] = val - KH[r][c];
+    }
+  }
+
+  float temp[N][N];
+  matMul(&IminusKH[0][0], &P[0][0], &temp[0][0], N, N, N);
+  copyMatrix(&temp[0][0], &P[0][0], N, N);
+}
+
+// ----------------------------------------------------------
+// INSEKF15 implementation
+// ----------------------------------------------------------
+
+INSEKF15::INSEKF15() : dt(0.005f) {
+  float p0[3] = {0.0f, 0.0f, 0.0f};
+  float v0[3] = {0.0f, 0.0f, 0.0f};
+  float q0[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+  float ba0[3] = {0.0f, 0.0f, 0.0f};
+  float bg0[3] = {0.0f, 0.0f, 0.0f};
+  initialize(p0, v0, q0, ba0, bg0);
+  setProcessNoiseFromSensors();
+  setMeasurementNoiseFromSensors();
+}
+
+void INSEKF15::initialize(const float *p0, const float *v0, const float *q0,
+                          const float *ba0, const float *bg0) {
+  for (int i = 0; i < 3; ++i) {
+    p_nom[i] = p0[i];
+    v_nom[i] = v0[i];
+    b_a_nom[i] = ba0[i];
+    b_g_nom[i] = bg0[i];
+  }
+  for (int i = 0; i < 4; ++i) {
+    q_nom[i] = q0[i];
+  }
+  quatNormalize(q_nom);
+  resetCovariance();
+}
+
+void INSEKF15::setDt(float dtSeconds) { dt = dtSeconds; }
+
+void INSEKF15::resetCovariance() {
+  zeroMatrix(&P[0][0], N, N);
+  for (int i = 0; i < N; ++i) {
+    P[i][i] = 1e-3f;
+  }
+}
+
+void INSEKF15::setProcessNoiseFromSensors() {
+  zeroMatrix(&Q[0][0], N, N);
+  const float Sa = 4.75e-4f;
+  const float Sg = 5.60e-4f;
+  const float AllanA = 8.71e-2f;
+  const float AllanG = 2.08e-1f;
+
+  const float sigma_v2 = Sa * dt;
+  const float sigma_p2 = (1.0f / 3.0f) * Sa * dt * dt * dt;
+  const float sigma_theta2 = Sg * dt;
+  const float Sb_a = AllanA * AllanA;
+  const float Sb_g = AllanG * AllanG;
+  const float q_ba = Sb_a * dt;
+  const float q_bg = Sb_g * dt;
+
+  for (int i = 0; i < 3; ++i) {
+    Q[i][i] = sigma_p2;
+    Q[3 + i][3 + i] = sigma_v2;
+    Q[6 + i][6 + i] = sigma_theta2;
+    Q[9 + i][9 + i] = q_ba;
+    Q[12 + i][12 + i] = q_bg;
+  }
+}
+
+void INSEKF15::setMeasurementNoiseFromSensors() {
+  const float sigma_baro = 3.0f;
+  R[0][0] = sigma_baro * sigma_baro;
+}
+
+void INSEKF15::buildFc(const float *a_corr, const float *w_corr,
+                       float Fc[N][N]) const {
+  zeroMatrix(&Fc[0][0], N, N);
+  float Rbn[9];
+  quatToRot(q_nom, Rbn);
+
+  float skew_a[9];
+  skew(a_corr, skew_a);
+  float skew_w[9];
+  skew(w_corr, skew_w);
+
+  for (int i = 0; i < 3; ++i) {
+    Fc[i][3 + i] = 1.0f;
+  }
+
+  float tmp[9];
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      float sum = 0.0f;
+      for (int k = 0; k < 3; ++k) {
+        sum += Rbn[r * 3 + k] * skew_a[k * 3 + c];
+      }
+      tmp[r * 3 + c] = -sum;
+    }
+  }
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      Fc[3 + r][6 + c] = tmp[r * 3 + c];
+    }
+  }
+
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      Fc[3 + r][9 + c] = -Rbn[r * 3 + c];
+    }
+  }
+
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      Fc[6 + r][6 + c] = -skew_w[r * 3 + c];
+    }
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    Fc[6 + i][12 + i] = -1.0f;
+  }
+}
+
+void INSEKF15::propagateCovariance(const float Fc[N][N]) {
+  float Fk[N][N];
+  zeroMatrix(&Fk[0][0], N, N);
+  for (int i = 0; i < N; ++i) {
+    Fk[i][i] = 1.0f + Fc[i][i] * dt;
+    for (int j = 0; j < N; ++j) {
+      if (i != j) {
+        Fk[i][j] += Fc[i][j] * dt;
+      }
+    }
+  }
+
+  float FP[N][N];
+  matMul(&Fk[0][0], &P[0][0], &FP[0][0], N, N, N);
+
+  float FkT[N][N];
+  matTrans(&Fk[0][0], &FkT[0][0], N, N);
+
+  float FPFt[N][N];
+  matMul(&FP[0][0], &FkT[0][0], &FPFt[0][0], N, N, N);
+
+  matAdd(&FPFt[0][0], &Q[0][0], &P[0][0], N, N);
+}
+
+void INSEKF15::injectErrorState(const float *dx) {
+  addVector(p_nom, dx, 3);
+  addVector(v_nom, dx + 3, 3);
+  applyDeltaTheta(q_nom, dx + 6);
+  addVector(b_a_nom, dx + 9, 3);
+  addVector(b_g_nom, dx + 12, 3);
+}
+
+void INSEKF15::predict(const float *a_m, const float *w_m) {
+  float a_corr[3];
+  float w_corr[3];
+  for (int i = 0; i < 3; ++i) {
+    a_corr[i] = a_m[i] - b_a_nom[i];
+    w_corr[i] = w_m[i] - b_g_nom[i];
+  }
+
+  float Rbn[9];
+  quatToRot(q_nom, Rbn);
+
+  float acc_nav[3];
+  for (int r = 0; r < 3; ++r) {
+    acc_nav[r] = Rbn[r * 3 + 0] * a_corr[0] + Rbn[r * 3 + 1] * a_corr[1] +
+                 Rbn[r * 3 + 2] * a_corr[2];
+  }
+  acc_nav[1] -= GRAVITY;
+
+  for (int i = 0; i < 3; ++i) {
+    p_nom[i] += v_nom[i] * dt;
+    v_nom[i] += acc_nav[i] * dt;
+  }
+  quatIntegrate(q_nom, w_corr, dt, q_nom);
+
+  float Fc[N][N];
+  buildFc(a_corr, w_corr, Fc);
+  propagateCovariance(Fc);
+}
+
+void INSEKF15::updateBaro(float z_baro) {
+  float innovation = z_baro - p_nom[1];
+
+  float H[1][N];
+  zeroMatrix(&H[0][0], 1, N);
+  H[0][1] = 1.0f;
+
+  float PHt[N];
+  for (int r = 0; r < N; ++r) {
+    PHt[r] = P[r][1];
+  }
+
+  float S = P[1][1] + R[0][0];
+  float K[N];
+  for (int i = 0; i < N; ++i) {
+    K[i] = PHt[i] / S;
+  }
+
+  float dx[N];
+  for (int i = 0; i < N; ++i) {
+    dx[i] = K[i] * innovation;
+  }
+  injectErrorState(dx);
+
+  float KH[N][N];
+  zeroMatrix(&KH[0][0], N, N);
+  for (int r = 0; r < N; ++r) {
+    KH[r][1] = K[r];
+  }
+
+  float IminusKH[N][N];
+  for (int r = 0; r < N; ++r) {
+    for (int c = 0; c < N; ++c) {
+      float val = (r == c) ? 1.0f : 0.0f;
+      IminusKH[r][c] = val - KH[r][c];
+    }
+  }
+
+  float temp[N][N];
+  matMul(&IminusKH[0][0], &P[0][0], &temp[0][0], N, N, N);
+  copyMatrix(&temp[0][0], &P[0][0], N, N);
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,15 @@
 #include <Arduino.h>
 #include <Wire.h>
+#include "ins_ekf.h"
 #include "sensor_setup.h"
-// #include "ekf_sensor_fusion.h"
-// #include "orientation_estimation.h"
-// #include "datalogging.h"
 
-#include <vector>
-#include <numeric>
-#include <cmath>
+// Core loop at 200 Hz (5 ms)
+static const uint32_t LOOP_PERIOD_US = 5000;
+static const float DT_SEC = 0.005f;
+static const float DEG_TO_RAD = 0.017453292519943295f;
 
-const float COLLECTION_DURATION_SECONDS = 10.0f; // exposed collection duration
-
-const uint32_t LOOP_PERIOD_US = 5000; // 200 Hz core loop
+INSEKF12 ekf12;
+INSEKF15 ekf15;
 
 void setup() {
   Serial.begin(115200);
@@ -20,161 +18,72 @@ void setup() {
   }
 
   setupSensors();
-  Serial.println("Beginning sensor noise characterization run...");
-  Serial.print("Configured collection duration (s): ");
-  Serial.println(COLLECTION_DURATION_SECONDS, 3);
+
+  float p0[3] = {0.0f, 0.0f, 0.0f};
+  float v0[3] = {0.0f, 0.0f, 0.0f};
+  float q0[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+  float ba0[3] = {0.0f, 0.0f, 0.0f};
+  float bg0[3] = {0.0f, 0.0f, 0.0f};
+
+  ekf12.initialize(p0, v0, q0, ba0, bg0);
+  ekf12.setDt(DT_SEC);
+  ekf12.setProcessNoiseFromSensors();
+  ekf12.setMeasurementNoiseFromSensors();
+
+  ekf15.initialize(p0, v0, q0, ba0, bg0);
+  ekf15.setDt(DT_SEC);
+  ekf15.setProcessNoiseFromSensors();
+  ekf15.setMeasurementNoiseFromSensors();
+
+  Serial.println("INS EKF initialized (12- and 15-state).");
 }
 
 void loop() {
   static uint32_t lastUpdate = micros();
   uint32_t now = micros();
   uint32_t elapsed = now - lastUpdate;
-
   if (elapsed < LOOP_PERIOD_US) {
     return;
   }
-
   lastUpdate = now;
 
-  static bool initializedBuffers = false;
-  static uint32_t startMillis = millis();
-  static std::vector<float> bnoAccelX, bnoAccelY, bnoAccelZ;
-  static std::vector<float> bnoGyroX, bnoGyroY, bnoGyroZ;
-  static std::vector<float> bnoMagX, bnoMagY, bnoMagZ;
-  static std::vector<float> bmxAccelX, bmxAccelY, bmxAccelZ;
-  static std::vector<float> bmxGyroX, bmxGyroY, bmxGyroZ;
-  static std::vector<float> bmxMagX, bmxMagY, bmxMagZ;
-  static std::vector<float> baroAltitude;
+  float ax = 0.0f, ay = 0.0f, az = 0.0f;
+  float gx = 0.0f, gy = 0.0f, gz = 0.0f;
+  float mx = 0.0f, my = 0.0f, mz = 0.0f;
 
-  if (!initializedBuffers) {
-    bnoAccelX.reserve(2000);
-    bnoAccelY.reserve(2000);
-    bnoAccelZ.reserve(2000);
-    bnoGyroX.reserve(2000);
-    bnoGyroY.reserve(2000);
-    bnoGyroZ.reserve(2000);
-    bnoMagX.reserve(2000);
-    bnoMagY.reserve(2000);
-    bnoMagZ.reserve(2000);
-    bmxAccelX.reserve(2000);
-    bmxAccelY.reserve(2000);
-    bmxAccelZ.reserve(2000);
-    bmxGyroX.reserve(2000);
-    bmxGyroY.reserve(2000);
-    bmxGyroZ.reserve(2000);
-    bmxMagX.reserve(2000);
-    bmxMagY.reserve(2000);
-    bmxMagZ.reserve(2000);
-    baroAltitude.reserve(2000);
-    initializedBuffers = true;
-  }
-
-  float bnoAx, bnoAy, bnoAz, bnoGx, bnoGy, bnoGz, bnoMx, bnoMy, bnoMz;
-  getSensorData(bnoAx, bnoAy, bnoAz, bnoGx, bnoGy, bnoGz, bnoMx, bnoMy, bnoMz);
-
-  float bmxAx = 0.0f, bmxAy = 0.0f, bmxAz = 0.0f;
-  float bmxGx = 0.0f, bmxGy = 0.0f, bmxGz = 0.0f;
-  float bmxMx = 0.0f, bmxMy = 0.0f, bmxMz = 0.0f;
-  bool bmxOk = getBMXSensorData(bmxAx, bmxAy, bmxAz, bmxGx, bmxGy, bmxGz, bmxMx, bmxMy, bmxMz);
-
-  float relAlt = getRelativeAltitude();
-
-  bnoAccelX.push_back(bnoAx);
-  bnoAccelY.push_back(bnoAy);
-  bnoAccelZ.push_back(bnoAz);
-  bnoGyroX.push_back(bnoGx);
-  bnoGyroY.push_back(bnoGy);
-  bnoGyroZ.push_back(bnoGz);
-  bnoMagX.push_back(bnoMx);
-  bnoMagY.push_back(bnoMy);
-  bnoMagZ.push_back(bnoMz);
-  baroAltitude.push_back(relAlt);
-
-  if (bmxOk) {
-    bmxAccelX.push_back(bmxAx);
-    bmxAccelY.push_back(bmxAy);
-    bmxAccelZ.push_back(bmxAz);
-    bmxGyroX.push_back(bmxGx);
-    bmxGyroY.push_back(bmxGy);
-    bmxGyroZ.push_back(bmxGz);
-    bmxMagX.push_back(bmxMx);
-    bmxMagY.push_back(bmxMy);
-    bmxMagZ.push_back(bmxMz);
-  }
-
-  float elapsedSeconds = (millis() - startMillis) / 1000.0f;
-  if (elapsedSeconds < COLLECTION_DURATION_SECONDS) {
+  bool bmxOk = getBMXSensorData(ax, ay, az, gx, gy, gz, mx, my, mz);
+  if (!bmxOk) {
+    // If BMX is not ready yet, skip this iteration.
     return;
   }
 
-  Serial.println("Collection complete. Computing statistics...");
-  const float sampleRateHz = 1e6f / static_cast<float>(LOOP_PERIOD_US);
+  float gyro_rad[3] = {gx * DEG_TO_RAD, gy * DEG_TO_RAD, gz * DEG_TO_RAD};
+  float accel_mps2[3] = {ax, ay, az};
 
-  auto printStats = [&](const char *label, const std::vector<float> &data) {
-    if (data.empty()) {
-      Serial.print(label);
-      Serial.println(": no data recorded");
-      return;
-    }
-    const size_t n = data.size();
-    float mean = std::accumulate(data.begin(), data.end(), 0.0f) / n;
-    float variance = 0.0f;
-    for (float v : data) {
-      float diff = v - mean;
-      variance += diff * diff;
-    }
-    variance /= (n > 1 ? (n - 1) : 1);
-    float stddev = sqrtf(variance);
+  ekf12.predict(accel_mps2, gyro_rad);
+  ekf15.predict(accel_mps2, gyro_rad);
 
-    float allanNumerator = 0.0f;
-    if (n > 1) {
-      for (size_t i = 0; i + 1 < n; ++i) {
-        float delta = data[i + 1] - data[i];
-        allanNumerator += delta * delta;
-      }
-      allanNumerator /= (2.0f * (n - 1));
-    }
-    float allanDeviation = sqrtf(allanNumerator);
+  float relAlt = getRelativeAltitude();
+  ekf12.updateBaro(relAlt);
+  ekf15.updateBaro(relAlt);
 
-    float psd = variance / sampleRateHz;
-
-    Serial.print(label);
-    Serial.print(",mean:");
-    Serial.print(mean, 6);
-    Serial.print(",std:");
-    Serial.print(stddev, 6);
-    Serial.print(",allan:");
-    Serial.print(allanDeviation, 6);
-    Serial.print(",psd:");
-    Serial.println(psd, 6);
-  };
-
-  printStats("BNO055_AX", bnoAccelX);
-  printStats("BNO055_AY", bnoAccelY);
-  printStats("BNO055_AZ", bnoAccelZ);
-  printStats("BNO055_GX", bnoGyroX);
-  printStats("BNO055_GY", bnoGyroY);
-  printStats("BNO055_GZ", bnoGyroZ);
-  printStats("BNO055_MX", bnoMagX);
-  printStats("BNO055_MY", bnoMagY);
-  printStats("BNO055_MZ", bnoMagZ);
-
-  printStats("BMX160_AX", bmxAccelX);
-  printStats("BMX160_AY", bmxAccelY);
-  printStats("BMX160_AZ", bmxAccelZ);
-  printStats("BMX160_GX", bmxGyroX);
-  printStats("BMX160_GY", bmxGyroY);
-  printStats("BMX160_GZ", bmxGyroZ);
-  printStats("BMX160_MX", bmxMagX);
-  printStats("BMX160_MY", bmxMagY);
-  printStats("BMX160_MZ", bmxMagZ);
-
-  printStats("BARO_ALT", baroAltitude);
-
-  Serial.println("Noise characterization complete. Please capture this log to a text file on the host PC.");
-
-  while (true) {
-    delay(1000);
+  static uint32_t logCounter = 0;
+  if ((logCounter++ % 20U) == 0U) { // 10 Hz logging
+    const float *p = ekf15.position();
+    const float *v = ekf15.velocity();
+    const float *q = ekf15.quaternion();
+    Serial.print("EKF15 p[m]: ");
+    Serial.print(p[0], 3); Serial.print(", ");
+    Serial.print(p[1], 3); Serial.print(", ");
+    Serial.print(p[2], 3); Serial.print(" | v[m/s]: ");
+    Serial.print(v[0], 3); Serial.print(", ");
+    Serial.print(v[1], 3); Serial.print(", ");
+    Serial.print(v[2], 3); Serial.print(" | q: ");
+    Serial.print(q[0], 4); Serial.print(", ");
+    Serial.print(q[1], 4); Serial.print(", ");
+    Serial.print(q[2], 4); Serial.print(", ");
+    Serial.print(q[3], 4); Serial.print(" | alt: ");
+    Serial.println(relAlt, 3);
   }
 }
 


### PR DESCRIPTION
## Summary
- add reusable 12-state and 15-state INS error-state EKF classes with Teensy-friendly APIs
- derive and apply process/measurement noise from BMX160/BMP388 statistics and propagate covariance
- update main loop to run the new EKFs at 200 Hz using existing sensor interfaces and barometric updates

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346668566c8329a3344089baa46559)