### PR TITLE
Refactor EKF output and cleanup

### DIFF
--- a/src/datalogging.cpp
+++ b/src/datalogging.cpp
@@ -1,9 +1,10 @@
+#include <Arduino.h>
+#include <SD.h>
+#include <SPI.h>
+
 #include "ekf_sensor_fusion.h"
 #include "orientation_estimation.h"
 #include "sensor_setup.h"
-#include <SD.h>
-#include <SPI.h>
-#include <Arduino.h>
 
 File rawDataFile;
 File filteredDataFile;

--- a/src/ekf_sensor_fusion.cpp
+++ b/src/ekf_sensor_fusion.cpp
@@ -1,7 +1,8 @@
 #include <Arduino.h>
-#include "sensor_setup.h"
 #include <ArduinoEigen.h>
 #include <math.h>
+
+#include "sensor_setup.h"
 
 static const int n_x = 6;
 static const int n_z = 1;

--- a/src/ins_ekf.cpp
+++ b/src/ins_ekf.cpp
@@ -1,4 +1,6 @@
 #include "ins_ekf.h"
+
+#include <cstddef>
 #include <math.h>
 
 static const float GRAVITY = 9.80665f;
@@ -8,13 +10,6 @@ static void zeroMatrix(float *M, int rows, int cols) {
     for (int c = 0; c < cols; ++c) {
       M[r * cols + c] = 0.0f;
     }
-  }
-}
-
-static void identityMatrix(float *M, int n) {
-  zeroMatrix(M, n, n);
-  for (int i = 0; i < n; ++i) {
-    M[i * n + i] = 1.0f;
   }
 }
 
@@ -28,7 +23,6 @@ static void copyMatrix(const float *A, float *B, int rows, int cols) {
 
 static void matMul(const float *A, const float *B, float *C, int m, int n,
                    int p) {
-  // C = A(mxn) * B(nxp)
   for (int i = 0; i < m; ++i) {
     for (int j = 0; j < p; ++j) {
       float sum = 0.0f;
@@ -45,15 +39,6 @@ static void matAdd(const float *A, const float *B, float *C, int rows,
   for (int r = 0; r < rows; ++r) {
     for (int c = 0; c < cols; ++c) {
       C[r * cols + c] = A[r * cols + c] + B[r * cols + c];
-    }
-  }
-}
-
-static void matSub(const float *A, const float *B, float *C, int rows,
-                   int cols) {
-  for (int r = 0; r < rows; ++r) {
-    for (int c = 0; c < cols; ++c) {
-      C[r * cols + c] = A[r * cols + c] - B[r * cols + c];
     }
   }
 }
@@ -160,6 +145,72 @@ static void addVector(float *dst, const float *src, int n) {
   }
 }
 
+template <size_t N>
+void resetCovarianceMatrix(float (&P)[N][N]) {
+  zeroMatrix(&P[0][0], static_cast<int>(N), static_cast<int>(N));
+  for (size_t i = 0U; i < N; ++i) {
+    P[i][i] = 1e-3f;
+  }
+}
+
+template <size_t N>
+void propagateCovarianceMatrix(float (&P)[N][N], const float (&Q)[N][N],
+                               const float (&Fc)[N][N], float dt) {
+  float Fk[N][N];
+  zeroMatrix(&Fk[0][0], static_cast<int>(N), static_cast<int>(N));
+  for (size_t i = 0U; i < N; ++i) {
+    Fk[i][i] = 1.0f + Fc[i][i] * dt;
+    for (size_t j = 0U; j < N; ++j) {
+      if (i != j) {
+        Fk[i][j] += Fc[i][j] * dt;
+      }
+    }
+  }
+
+  float FP[N][N];
+  matMul(&Fk[0][0], &P[0][0], &FP[0][0], static_cast<int>(N),
+         static_cast<int>(N), static_cast<int>(N));
+
+  float FkT[N][N];
+  matTrans(&Fk[0][0], &FkT[0][0], static_cast<int>(N), static_cast<int>(N));
+
+  float FPFt[N][N];
+  matMul(&FP[0][0], &FkT[0][0], &FPFt[0][0], static_cast<int>(N),
+         static_cast<int>(N), static_cast<int>(N));
+
+  matAdd(&FPFt[0][0], &Q[0][0], &P[0][0], static_cast<int>(N),
+         static_cast<int>(N));
+}
+
+template <size_t N>
+void applyBaroUpdate(float (&P)[N][N], const float (&R)[1][1], float innovation,
+                     float (&dxOut)[N]) {
+  float S = P[1][1] + R[0][0];
+  float gainVec[N];
+  for (size_t i = 0U; i < N; ++i) {
+    gainVec[i] = P[i][1] / S;
+    dxOut[i] = gainVec[i] * innovation;
+  }
+
+  float KH[N][N] = {};
+  for (size_t r = 0U; r < N; ++r) {
+    KH[r][1] = gainVec[r];
+  }
+
+  float IminusKH[N][N];
+  for (size_t r = 0U; r < N; ++r) {
+    for (size_t c = 0U; c < N; ++c) {
+      float val = (r == c) ? 1.0f : 0.0f;
+      IminusKH[r][c] = val - KH[r][c];
+    }
+  }
+
+  float temp[N][N];
+  matMul(&IminusKH[0][0], &P[0][0], &temp[0][0], static_cast<int>(N),
+         static_cast<int>(N), static_cast<int>(N));
+  copyMatrix(&temp[0][0], &P[0][0], static_cast<int>(N), static_cast<int>(N));
+}
+
 // ----------------------------------------------------------
 // INSEKF12 implementation
 // ----------------------------------------------------------
@@ -193,10 +244,7 @@ void INSEKF12::initialize(const float *p0, const float *v0, const float *q0,
 void INSEKF12::setDt(float dtSeconds) { dt = dtSeconds; }
 
 void INSEKF12::resetCovariance() {
-  zeroMatrix(&P[0][0], N, N);
-  for (int i = 0; i < N; ++i) {
-    P[i][i] = 1e-3f;
-  }
+  resetCovarianceMatrix(P);
 }
 
 void INSEKF12::setProcessNoiseFromSensors() {
@@ -274,27 +322,7 @@ void INSEKF12::buildFc(const float *a_corr, const float *w_corr,
 }
 
 void INSEKF12::propagateCovariance(const float Fc[N][N]) {
-  float Fk[N][N];
-  zeroMatrix(&Fk[0][0], N, N);
-  for (int i = 0; i < N; ++i) {
-    Fk[i][i] = 1.0f + Fc[i][i] * dt;
-    for (int j = 0; j < N; ++j) {
-      if (i != j) {
-        Fk[i][j] += Fc[i][j] * dt;
-      }
-    }
-  }
-
-  float FP[N][N];
-  matMul(&Fk[0][0], &P[0][0], &FP[0][0], N, N, N);
-
-  float FkT[N][N];
-  matTrans(&Fk[0][0], &FkT[0][0], N, N);
-
-  float FPFt[N][N];
-  matMul(&FP[0][0], &FkT[0][0], &FPFt[0][0], N, N, N);
-
-  matAdd(&FPFt[0][0], &Q[0][0], &P[0][0], N, N);
+  propagateCovarianceMatrix(P, Q, Fc, dt);
 }
 
 void INSEKF12::injectErrorState(const float *dx) {
@@ -334,47 +362,10 @@ void INSEKF12::predict(const float *a_m, const float *w_m) {
 }
 
 void INSEKF12::updateBaro(float z_baro) {
-  // H = [0 1 0 0 ...]
-  float H[1][N];
-  zeroMatrix(&H[0][0], 1, N);
-  H[0][1] = 1.0f;
-
-  float PHt[N];
-  for (int r = 0; r < N; ++r) {
-    PHt[r] = P[r][1];
-  }
-
-  float S = P[1][1] + R[0][0];
-  float K[N];
-  for (int i = 0; i < N; ++i) {
-    K[i] = PHt[i] / S;
-  }
-
   float innovation = z_baro - p_nom[1];
   float dx[N];
-  for (int i = 0; i < N; ++i) {
-    dx[i] = K[i] * innovation;
-  }
+  applyBaroUpdate(P, R, innovation, dx);
   injectErrorState(dx);
-
-  // P = (I-KH)P
-  float KH[N][N];
-  zeroMatrix(&KH[0][0], N, N);
-  for (int r = 0; r < N; ++r) {
-    KH[r][1] = K[r];
-  }
-
-  float IminusKH[N][N];
-  for (int r = 0; r < N; ++r) {
-    for (int c = 0; c < N; ++c) {
-      float val = (r == c) ? 1.0f : 0.0f;
-      IminusKH[r][c] = val - KH[r][c];
-    }
-  }
-
-  float temp[N][N];
-  matMul(&IminusKH[0][0], &P[0][0], &temp[0][0], N, N, N);
-  copyMatrix(&temp[0][0], &P[0][0], N, N);
 }
 
 // ----------------------------------------------------------
@@ -410,10 +401,7 @@ void INSEKF15::initialize(const float *p0, const float *v0, const float *q0,
 void INSEKF15::setDt(float dtSeconds) { dt = dtSeconds; }
 
 void INSEKF15::resetCovariance() {
-  zeroMatrix(&P[0][0], N, N);
-  for (int i = 0; i < N; ++i) {
-    P[i][i] = 1e-3f;
-  }
+  resetCovarianceMatrix(P);
 }
 
 void INSEKF15::setProcessNoiseFromSensors() {
@@ -494,27 +482,7 @@ void INSEKF15::buildFc(const float *a_corr, const float *w_corr,
 }
 
 void INSEKF15::propagateCovariance(const float Fc[N][N]) {
-  float Fk[N][N];
-  zeroMatrix(&Fk[0][0], N, N);
-  for (int i = 0; i < N; ++i) {
-    Fk[i][i] = 1.0f + Fc[i][i] * dt;
-    for (int j = 0; j < N; ++j) {
-      if (i != j) {
-        Fk[i][j] += Fc[i][j] * dt;
-      }
-    }
-  }
-
-  float FP[N][N];
-  matMul(&Fk[0][0], &P[0][0], &FP[0][0], N, N, N);
-
-  float FkT[N][N];
-  matTrans(&Fk[0][0], &FkT[0][0], N, N);
-
-  float FPFt[N][N];
-  matMul(&FP[0][0], &FkT[0][0], &FPFt[0][0], N, N, N);
-
-  matAdd(&FPFt[0][0], &Q[0][0], &P[0][0], N, N);
+  propagateCovarianceMatrix(P, Q, Fc, dt);
 }
 
 void INSEKF15::injectErrorState(const float *dx) {
@@ -556,44 +524,8 @@ void INSEKF15::predict(const float *a_m, const float *w_m) {
 
 void INSEKF15::updateBaro(float z_baro) {
   float innovation = z_baro - p_nom[1];
-
-  float H[1][N];
-  zeroMatrix(&H[0][0], 1, N);
-  H[0][1] = 1.0f;
-
-  float PHt[N];
-  for (int r = 0; r < N; ++r) {
-    PHt[r] = P[r][1];
-  }
-
-  float S = P[1][1] + R[0][0];
-  float K[N];
-  for (int i = 0; i < N; ++i) {
-    K[i] = PHt[i] / S;
-  }
-
   float dx[N];
-  for (int i = 0; i < N; ++i) {
-    dx[i] = K[i] * innovation;
-  }
+  applyBaroUpdate(P, R, innovation, dx);
   injectErrorState(dx);
-
-  float KH[N][N];
-  zeroMatrix(&KH[0][0], N, N);
-  for (int r = 0; r < N; ++r) {
-    KH[r][1] = K[r];
-  }
-
-  float IminusKH[N][N];
-  for (int r = 0; r < N; ++r) {
-    for (int c = 0; c < N; ++c) {
-      float val = (r == c) ? 1.0f : 0.0f;
-      IminusKH[r][c] = val - KH[r][c];
-    }
-  }
-
-  float temp[N][N];
-  matMul(&IminusKH[0][0], &P[0][0], &temp[0][0], N, N, N);
-  copyMatrix(&temp[0][0], &P[0][0], N, N);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,93 @@
 #include <Arduino.h>
-#include <Wire.h>
+#include <math.h>
+
 #include "ins_ekf.h"
 #include "sensor_setup.h"
 
 // Core loop at 200 Hz (5 ms)
-static const uint32_t LOOP_PERIOD_US = 5000;
-static const float DT_SEC = 0.005f;
-static const float DEG_TO_RAD = 0.017453292519943295f;
+namespace {
+constexpr uint32_t LOOP_PERIOD_US = 5000U;
+constexpr float DT_SEC = 0.005f;
+constexpr float DEG_TO_RAD = 0.017453292519943295f;
+constexpr uint8_t PLOT_PRECISION = 4U;
+
+void quaternionToEuler(const float *q, float &roll, float &pitch, float &yaw) {
+  const float sinr_cosp = 2.0f * (q[0] * q[1] + q[2] * q[3]);
+  const float cosr_cosp = 1.0f - 2.0f * (q[1] * q[1] + q[2] * q[2]);
+  roll = atan2f(sinr_cosp, cosr_cosp);
+
+  const float sinp = 2.0f * (q[0] * q[2] - q[3] * q[1]);
+  if (fabsf(sinp) >= 1.0f) {
+    pitch = copysignf(PI / 2.0f, sinp);
+  } else {
+    pitch = asinf(sinp);
+  }
+
+  const float siny_cosp = 2.0f * (q[0] * q[3] + q[1] * q[2]);
+  const float cosy_cosp = 1.0f - 2.0f * (q[2] * q[2] + q[3] * q[3]);
+  yaw = atan2f(siny_cosp, cosy_cosp);
+}
+
+void emitPlotLine(const INSEKF15 &ekf) {
+  const float *position = ekf.position();
+  const float *velocity = ekf.velocity();
+  const float *quat = ekf.quaternion();
+
+  float roll = 0.0f;
+  float pitch = 0.0f;
+  float yaw = 0.0f;
+  quaternionToEuler(quat, roll, pitch, yaw);
+
+  Serial.print('>');
+  Serial.print("roll:");
+  Serial.print(roll, PLOT_PRECISION);
+  Serial.print(",pitch:");
+  Serial.print(pitch, PLOT_PRECISION);
+  Serial.print(",yaw:");
+  Serial.print(yaw, PLOT_PRECISION);
+  Serial.print(",p_x:");
+  Serial.print(position[0], PLOT_PRECISION);
+  Serial.print(",p_y:");
+  Serial.print(position[1], PLOT_PRECISION);
+  Serial.print(",p_z:");
+  Serial.print(position[2], PLOT_PRECISION);
+  Serial.print(",v_x:");
+  Serial.print(velocity[0], PLOT_PRECISION);
+  Serial.print(",v_y:");
+  Serial.print(velocity[1], PLOT_PRECISION);
+  Serial.print(",v_z:");
+  Serial.print(velocity[2], PLOT_PRECISION);
+  Serial.print("\r\n");
+}
+
+void logEkfStatus(const INSEKF15 &ekf, float relAlt) {
+  const float *p = ekf.position();
+  const float *v = ekf.velocity();
+  const float *q = ekf.quaternion();
+  Serial.print("EKF15 p[m]: ");
+  Serial.print(p[0], 3);
+  Serial.print(", ");
+  Serial.print(p[1], 3);
+  Serial.print(", ");
+  Serial.print(p[2], 3);
+  Serial.print(" | v[m/s]: ");
+  Serial.print(v[0], 3);
+  Serial.print(", ");
+  Serial.print(v[1], 3);
+  Serial.print(", ");
+  Serial.print(v[2], 3);
+  Serial.print(" | q: ");
+  Serial.print(q[0], 4);
+  Serial.print(", ");
+  Serial.print(q[1], 4);
+  Serial.print(", ");
+  Serial.print(q[2], 4);
+  Serial.print(", ");
+  Serial.print(q[3], 4);
+  Serial.print(" | alt: ");
+  Serial.println(relAlt, 3);
+}
+} // namespace
 
 INSEKF12 ekf12;
 INSEKF15 ekf15;
@@ -67,23 +148,11 @@ void loop() {
   ekf12.updateBaro(relAlt);
   ekf15.updateBaro(relAlt);
 
+  emitPlotLine(ekf15);
+
   static uint32_t logCounter = 0;
   if ((logCounter++ % 20U) == 0U) { // 10 Hz logging
-    const float *p = ekf15.position();
-    const float *v = ekf15.velocity();
-    const float *q = ekf15.quaternion();
-    Serial.print("EKF15 p[m]: ");
-    Serial.print(p[0], 3); Serial.print(", ");
-    Serial.print(p[1], 3); Serial.print(", ");
-    Serial.print(p[2], 3); Serial.print(" | v[m/s]: ");
-    Serial.print(v[0], 3); Serial.print(", ");
-    Serial.print(v[1], 3); Serial.print(", ");
-    Serial.print(v[2], 3); Serial.print(" | q: ");
-    Serial.print(q[0], 4); Serial.print(", ");
-    Serial.print(q[1], 4); Serial.print(", ");
-    Serial.print(q[2], 4); Serial.print(", ");
-    Serial.print(q[3], 4); Serial.print(" | alt: ");
-    Serial.println(relAlt, 3);
+    logEkfStatus(ekf15, relAlt);
   }
 }
 

--- a/src/orientation_estimation.cpp
+++ b/src/orientation_estimation.cpp
@@ -1,12 +1,27 @@
 #include "orientation_estimation.h"
 
-static float integratedRoll = 0.0f;
-static float integratedPitch = 0.0f;
-static float integratedYaw = 0.0f;
+namespace {
+constexpr float FILTER_ALPHA = 0.7f;
+constexpr float RAD_TO_DEG_SQUARED = RAD_TO_DEG * RAD_TO_DEG;
 
-static float filteredGx = 0.0f;
-static float filteredGy = 0.0f;
-static float filteredGz = 0.0f;
+float integratedRoll = 0.0f;
+float integratedPitch = 0.0f;
+float integratedYaw = 0.0f;
+
+float filteredGx = 0.0f;
+float filteredGy = 0.0f;
+float filteredGz = 0.0f;
+
+float wrapAngle(float angle) {
+    while (angle < 0.0f) {
+        angle += 360.0f;
+    }
+    while (angle >= 360.0f) {
+        angle -= 360.0f;
+    }
+    return angle;
+}
+}
 
 void resetIntegratedAngles() {
     integratedRoll = 0.0f;
@@ -19,37 +34,14 @@ void resetIntegratedAngles() {
 }
 
 void updateIntegratedAngles(float gx, float gy, float gz, float dt) {
-    const float filterAlpha = 0.7f;
-    filteredGx = filterAlpha * gx + (1 - filterAlpha) * filteredGx;
-    filteredGy = filterAlpha * gy + (1 - filterAlpha) * filteredGy;
-    filteredGz = filterAlpha * gz + (1 - filterAlpha) * filteredGz;
+    const float filterComplement = 1.0f - FILTER_ALPHA;
+    filteredGx = FILTER_ALPHA * gx + filterComplement * filteredGx;
+    filteredGy = FILTER_ALPHA * gy + filterComplement * filteredGy;
+    filteredGz = FILTER_ALPHA * gz + filterComplement * filteredGz;
 
-    float k1_roll = filteredGy *  RAD_TO_DEG * RAD_TO_DEG;
-    float k2_roll = (filteredGy) *  RAD_TO_DEG * RAD_TO_DEG;
-    float k3_roll = (filteredGy) *  RAD_TO_DEG * RAD_TO_DEG;
-    float k4_roll = (filteredGy) *  RAD_TO_DEG * RAD_TO_DEG;
-    integratedRoll += (dt / 6.0f) * (k1_roll + 2*k2_roll + 2*k3_roll + k4_roll);
-
-    float k1_pitch = filteredGx *  RAD_TO_DEG * RAD_TO_DEG;
-    float k2_pitch = (filteredGx) *  RAD_TO_DEG * RAD_TO_DEG;
-    float k3_pitch = (filteredGx) *  RAD_TO_DEG * RAD_TO_DEG;
-    float k4_pitch = (filteredGx) * RAD_TO_DEG * RAD_TO_DEG;
-    integratedPitch += (dt / 6.0f) * (k1_pitch + 2*k2_pitch + 2*k3_pitch + k4_pitch);
-
-    float k1_yaw = filteredGz * RAD_TO_DEG * RAD_TO_DEG;
-    float k2_yaw = (filteredGz) * RAD_TO_DEG * RAD_TO_DEG;
-    float k3_yaw = (filteredGz) * RAD_TO_DEG * RAD_TO_DEG;
-    float k4_yaw = (filteredGz) * RAD_TO_DEG * RAD_TO_DEG;
-    integratedYaw += (dt / 6.0f) * (k1_yaw + 2*k2_yaw + 2*k3_yaw + k4_yaw);
-
-    while (integratedRoll < 0) integratedRoll += 360.0f;
-    while (integratedRoll >= 360.0f) integratedRoll -= 360.0f;
-
-    while (integratedPitch < 0) integratedPitch += 360.0f;
-    while (integratedPitch >= 360.0f) integratedPitch -= 360.0f;
-
-    while (integratedYaw < 0) integratedYaw += 360.0f;
-    while (integratedYaw >= 360.0f) integratedYaw -= 360.0f;
+    integratedRoll = wrapAngle(integratedRoll + filteredGy * RAD_TO_DEG_SQUARED * dt);
+    integratedPitch = wrapAngle(integratedPitch + filteredGx * RAD_TO_DEG_SQUARED * dt);
+    integratedYaw = wrapAngle(integratedYaw + filteredGz * RAD_TO_DEG_SQUARED * dt);
 }
 
 void getIntegratedAngles(float &roll, float &pitch, float &yaw) {


### PR DESCRIPTION
## Summary
- Format Serial plot output as a single EKF state line with quaternion-to-Euler conversion helpers
- Refactor EKF covariance and barometer update logic to reduce duplication and simplify orientation integration
- Tidy includes and structure for improved readability and standards alignment

## Testing
- pio run -t nobuild *(fails: PlatformIO not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346830fe1c8329a112317847283d6c)