### PR TITLE
Fix gyro conversion for EKF

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,9 +131,10 @@ void loop() {
     return;
   }
 
-  float gyro_rad[3] = {static_cast<float>(gx * RAD_TO_DEG),
-                       static_cast<float>(gy * RAD_TO_DEG),
-                       static_cast<float>(gz * RAD_TO_DEG)};
+  // Convert gyro measurements (deg/s from BMX160 driver) to rad/s for the EKF
+  float gyro_rad[3] = {static_cast<float>(gx * DEG_TO_RAD),
+                       static_cast<float>(gy * DEG_TO_RAD),
+                       static_cast<float>(gz * DEG_TO_RAD)};
   float accel_mps2[3] = {ax, ay, az};
 
   ekf15.predict(accel_mps2, gyro_rad);


### PR DESCRIPTION
## Summary
- convert BMX160 gyroscope readings to rad/s before feeding the EKF
- document the expected BMX160 units to avoid invalid quaternion updates

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b4bdbf8c8329959c2dccbb41b2c7)